### PR TITLE
Address issue #4 and update redact

### DIFF
--- a/util/helpers/modules/Command.js
+++ b/util/helpers/modules/Command.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { inspect } = require('util');
-
 /**
  * Provide some utility methods to parse the args of a message, check the required permissions...
  * @class Command
@@ -39,10 +37,7 @@ class Command {
             }
             if (!prefixes.find(p => p === prefix)) {
                 return resolve(undefined);
-            }
-            //Investigate issue #4
-            if (!command.toLowerCase) {
-                console.log(`Issue #4 occurrence spotted: ${inspect(command)}`);
+            } else if (!command) {
                 return resolve(undefined);
             }
             return resolve(client.commands.get(command.toLowerCase()) || client.commands.get(client.aliases.get(command.toLowerCase())));

--- a/util/helpers/modules/redact.js
+++ b/util/helpers/modules/redact.js
@@ -11,11 +11,15 @@ const redact = (client, string) => {
     const secondaryCredentials = [
         client.config.apiKeys.sentryDSN, 
         client.config.database.password, 
-        client.config.botLists.terminal.token, 
         client.config.apiKeys.weebSH,
         client.config.options.music.password,
         client.config.options.music.host
     ];
+    for (const botList in client.config.botLists) {
+        if (client.config.botLists[botList].token) {
+            secondaryCredentials.push(client.config.botLists[botList].token);
+        }
+    }
     for (const value of secondaryCredentials) {
         if (value) {
             credentials.push(value);


### PR DESCRIPTION
-After further investigations, issue #4 cause has been located: The parseCommand() method was only checking if the prefix was correct, not if the command was when it had been parsed by parseUnspacedCommand()
-Update redact to automatically hide all bot-lists tokens